### PR TITLE
Detect ch_id (underscored) token variant and fix param stripping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /vendor/
+/local/
 .gcloudignore
 .htaccess
 app.yaml

--- a/src/GateKeeper.php
+++ b/src/GateKeeper.php
@@ -54,8 +54,9 @@ class GateKeeper
         $this->setCookieDomain($server);
 
         // Token in URL
-        if (isset($get[self::TOKEN_URL])) {
-            $this->setCookie($get[self::TOKEN_URL]);
+        $urlToken = $this->getUrlToken($get);
+        if (!is_null($urlToken)) {
+            $this->setCookie($urlToken);
             // clean url and redirect
             $this->sanitizeURL($this->url, $get);
             header("Cache-Control: no-store, no-cache, must-revalidate, max-age=0");
@@ -72,30 +73,49 @@ class GateKeeper
     }
 
     /**
+     * Read the CrowdHandler token from the query parameters.
+     * Accepts both the canonical hyphenated key ('ch-id') and the
+     * underscored variant ('ch_id') that some proxies/frameworks produce.
+     * @param array $get An array of the current query string parameters
+     * @return string|null The token value, or null if not present
+     */
+    private function getUrlToken($get)
+    {
+        if (isset($get[self::TOKEN_URL])) {
+            return $get[self::TOKEN_URL];
+        }
+        $underscored = str_replace('-', '_', self::TOKEN_URL);
+        if (isset($get[$underscored])) {
+            return $get[$underscored];
+        }
+        return null;
+    }
+
+    /**
      * Removes crowdhandler specific query parameters on promotion
      * @param string $url The url that is currently being requested
-     * @param array $get An array of the current query sring parameters   
+     * @param array $get An array of the current query sring parameters
      */
     private function sanitizeURL ($url, $get)
     {
-        
+
         $parsed_url  = parse_url($url);
         $this->url = 'https://' . $parsed_url['host'] . $parsed_url['path'];
 
-        $ch_params_to_remove = array();
-        for ($i=0; $i < Count(self::CROWDHANDLER_PARAMS); $i++) {
-            if (isset($get[self::CROWDHANDLER_PARAMS[$i]]))
-            {
-                array_push($ch_params_to_remove, $get[self::CROWDHANDLER_PARAMS[$i]]);
-            }
+        // Strip every CrowdHandler param by key, covering both the hyphenated
+        // form ('ch-id') and the underscored form ('ch_id') that some
+        // proxies/frameworks produce, so none leak back into the clean URL.
+        $remaining_query_parameters = $get;
+        foreach (self::CROWDHANDLER_PARAMS as $param) {
+            unset($remaining_query_parameters[$param]);
+            unset($remaining_query_parameters[str_replace('-', '_', $param)]);
         }
 
-        $remaining_query_parameters = array_diff($get, $ch_params_to_remove);
         $remaining_query_parameters['ch-fresh'] = uniqid();
         if (Count($remaining_query_parameters) > 0) {
             $this->url = $this->url .= '?' . http_build_query($remaining_query_parameters);
         }
-       
+
     }
 
     private function detectClientIp($server)


### PR DESCRIPTION
Improves the resilience of the waiting-room return flow when the CrowdHandler token is delivered to PHP under the key `ch_id` instead of `ch-id`.

  When a visitor returns from the waiting room, the SDK reads the CrowdHandler token from the `ch-id` query parameter, persists it to a cookie, strips the CrowdHandler parameters, and redirects to a clean URL.

  In some hosting configurations — for example behind certain reverse proxies, API gateways, or framework middleware — the parameter key arrives as `ch_id` (underscore) rather than `ch-id`. The SDK previously matched only the exact
  `ch-id` key, so in those environments the token was not detected from the URL, was not written to the cookie, and the CrowdHandler parameters were not removed. A visitor without an existing cookie could then be redirected back to
  the waiting room repeatedly.

  - **`getUrlToken()`** — new helper that detects the token under both `ch-id` and `ch_id`. It applies to both the superglobal (`$_GET`) and PSR-7 (`getQueryParams()`) request paths.
  - **`sanitizeURL()`** — now removes CrowdHandler parameters **by key**, covering both the hyphenated and underscored spelling, so no CrowdHandler parameters can leak into the cleaned redirect URL. Matching by key (rather than by
  value) is more precise and reliably preserves unrelated application query parameters.

  Fully backwards compatible. There are no API or configuration changes, and requests using the standard `ch-id` key behave exactly as before — the new handling is purely additive.

  Verified that the token is detected when supplied as `ch_id`; that the cleaned URL retains the application's own query parameters and a fresh cache-buster while dropping every CrowdHandler parameter in either spelling; and that
  the existing `ch-id` flow is unchanged.